### PR TITLE
rbwebhooks: Add support for some additional events

### DIFF
--- a/rbwebhooks/rbwebhooks/forms.py
+++ b/rbwebhooks/rbwebhooks/forms.py
@@ -5,5 +5,9 @@ from djblets.extensions.forms import SettingsForm
 
 
 class WebHooksSettingsForm(SettingsForm):
+    username = forms.CharField(max_length=64,
+        help_text=_("Basic auth username to use for POST requests"))
+    password = forms.CharField(max_length=64, widget=forms.PasswordInput(),
+        help_text=_("Basic auth password to use for POST requests"))
     attempts = forms.IntegerField(min_value=0, initial=1,
         help_text=_("The number of times to attempt each request."))

--- a/rbwebhooks/setup.py
+++ b/rbwebhooks/setup.py
@@ -3,14 +3,15 @@ from setuptools import setup
 
 
 PACKAGE = "rbwebhooks"
-VERSION = "0.1"
+VERSION = "0.2"
 
 setup(
     name=PACKAGE,
     version=VERSION,
     description="RBWebHooks, a webhook extension for Review Board",
-    author="Steven MacLeod",
+    author="Steven MacLeod, Ondrej Kupka",
     packages=["rbwebhooks"],
+    install_requires=["requests==2.0.1"],
     entry_points={
         'reviewboard.extensions':
             '%s = rbwebhooks.extension:RBWebHooksExtension' % PACKAGE,


### PR DESCRIPTION
Namely the events newly supported are review_request_closed,
review_request_reopened and review_request_approved.

The POST requests also contain additional header now that contains the event
that the request represents. The header is called X-ReviewBoard-Event.
