### PR TITLE
fix review_together extension

### DIFF
--- a/review_together/AUTHORS
+++ b/review_together/AUTHORS
@@ -3,4 +3,5 @@ Lead developer(s):
 
 Contributors:
     * Peter Tran
+    * Jakub Zytka
 

--- a/review_together/review_together/static/js/review-together.js
+++ b/review_together/review_together/static/js/review-together.js
@@ -1,4 +1,4 @@
-var ReviewTogetherJS = {};
+window.ReviewTogetherJS = {};
 
 (function() {
     /*

--- a/review_together/setup.py
+++ b/review_together/setup.py
@@ -1,7 +1,7 @@
 from reviewboard.extensions.packaging import setup
 
 PACKAGE = "review-together"
-VERSION = "1.0.0a"
+VERSION = "1.0.0b"
 
 setup(
     name=PACKAGE,

--- a/review_together/setup.py
+++ b/review_together/setup.py
@@ -1,5 +1,4 @@
-from setuptools import setup
-
+from reviewboard.extensions.packaging import setup
 
 PACKAGE = "review-together"
 VERSION = "1.0.0a"


### PR DESCRIPTION
I believe the original version never actually worked. The egg available in pypi is broken beyond repair as well. It seems noone has ever tested it. It's a pity, since review_together is a killer-feature.

Oh yeah, I noticed you don't accept pull-requests, but I don't feel like signing on yet another service just to upload a patch. Sorry about that.

The fix consists of two parts:
* use proper setup for packaging (right now the css and js files are not packaged because setuptools are used)
* put some extension object in global namespace (right now the object is wrapped in a closure and further accesses do not succeed)

I also allowed myself to include me in contributors list and do a version bump. I'm not particularly attached to these changes. You can get rid of them if you like.