### PR TITLE
Fixing for reviewboard 7 - updated extension.py

### DIFF
--- a/rbnotefield/rbnotefield/extension.py
+++ b/rbnotefield/rbnotefield/extension.py
@@ -1,6 +1,6 @@
 """Review Board Extension for adding a "notes" field."""
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from reviewboard.extensions.base import Extension
 from reviewboard.extensions.hooks import ReviewRequestFieldsHook
 from reviewboard.reviews.fields import BaseTextAreaField


### PR DESCRIPTION
Adding support for Reviewboard 7, djando changed the name of the function.

This pull request is to fix the issue of installing the extension rbnotefield for Reviewboard version 7